### PR TITLE
Fix build errors

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -57,6 +57,7 @@
     "undici": "^7.16.0",
     "vite": "^6.3.0",
     "vite-plugin-pwa": "^1.2.0",
+    "workbox-window": "^7.4.0",
     "wrangler": "^3.90.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,9 @@ importers:
       vite-plugin-pwa:
         specifier: ^1.2.0
         version: 1.2.0(vite@6.4.1(@types/node@25.0.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0)
+      workbox-window:
+        specifier: ^7.4.0
+        version: 7.4.0
       wrangler:
         specifier: ^3.90.0
         version: 3.114.15(@cloudflare/workers-types@4.20251211.0)


### PR DESCRIPTION
pnpm's strict dependency resolution prevented workbox-window from being resolved during build. Adding it as an explicit devDependency fixes the Rollup import resolution error.