### PR TITLE
Fix duplicate hashtag detection in SNS share by using transformed text

### DIFF
--- a/apps/web/src/lib/utils/sns-share.ts
+++ b/apps/web/src/lib/utils/sns-share.ts
@@ -101,7 +101,8 @@ export function transformContentForSns(options: SnsShareOptions): TransformedCon
   }
 
   // 3. t タグからハッシュタグを追加（コンテンツに含まれていないもののみ）
-  const hashtags = extractHashtagsForSns(tags, content)
+  // スーパーメンション変換後の text を渡すことで、@@mention 由来のハッシュタグとの重複もチェック
+  const hashtags = extractHashtagsForSns(tags, text)
   if (hashtags.length > 0) {
     text = text + '\n\n' + hashtags.map((t) => `#${t}`).join(' ')
   }


### PR DESCRIPTION
## Summary
Fixed a bug in the SNS share hashtag extraction logic where duplicate hashtags were not being properly detected when they originated from super mentions (@@mention syntax).

## Changes
- Modified `transformContentForSns()` to pass the transformed `text` (after super mention conversion) to `extractHashtagsForSns()` instead of the original `content`
- This ensures that hashtags derived from super mentions are properly checked against existing hashtags in the content, preventing duplicates

## Implementation Details
The issue occurred because the function was checking for duplicate hashtags against the original `content` before super mentions were converted to their text representation. By passing the already-transformed `text` to the hashtag extraction function, we now correctly identify and avoid adding duplicate hashtags that may have been introduced during the super mention conversion process.

https://claude.ai/code/session_012oMFYetf4uuoo8upodVDoL