### PR TITLE
Improve Web Share API detection and fallback handling

### DIFF
--- a/apps/web/src/hooks/ui/useShare.ts
+++ b/apps/web/src/hooks/ui/useShare.ts
@@ -5,15 +5,23 @@ export function useShare() {
   const [copied, setCopied] = useState(false)
 
   const share = async (url: string): Promise<boolean> => {
-    if (navigator.share) {
+    const shareData = { url }
+
+    // Check if Web Share API is available and can share this data
+    const canUseShare =
+      typeof navigator.share === 'function' &&
+      typeof navigator.canShare === 'function' &&
+      navigator.canShare(shareData)
+
+    if (canUseShare) {
       try {
-        await navigator.share({ url })
+        await navigator.share(shareData)
         return true
       } catch (e) {
         if ((e as Error).name === 'AbortError') {
           return false
         }
-        // Fallback to copy
+        // Fallback to copy for other errors
       }
     }
 


### PR DESCRIPTION
## Summary
Enhanced the `useShare` hook to properly detect Web Share API availability before attempting to use it, and improved error handling with clearer fallback logic.

## Key Changes
- Added proper feature detection using `navigator.canShare()` to validate if the share data can be shared before attempting to call `navigator.share()`
- Improved type safety by explicitly checking that both `navigator.share` and `navigator.canShare` are functions
- Clarified fallback behavior with a more descriptive comment distinguishing between user cancellation (AbortError) and other errors
- Extracted share data into a variable for better readability and reusability

## Implementation Details
The Web Share API's `canShare()` method is now used to validate that the provided data can be shared on the current platform before attempting the share operation. This prevents unnecessary errors and provides a more robust fallback to the copy-to-clipboard mechanism when sharing is not supported or fails for reasons other than user cancellation.

https://claude.ai/code/session_01RchErtiRwvsH8HNR6XGn8w