### PR TITLE
fix: prevent video player freeze on rapid play/pause toggling

### DIFF
--- a/apps/web/src/components/image/VideoEditor.tsx
+++ b/apps/web/src/components/image/VideoEditor.tsx
@@ -148,9 +148,7 @@ export function VideoEditor({ file, onComplete, onCancel, onError }: VideoEditor
 
   const togglePlay = () => {
     if (playing) {
-      if (videoRef.current) {
-        safePause(videoRef.current)
-      }
+      // safePause is handled by the effect cleanup when playing becomes false
       setPlaying(false)
     } else {
       // Always start from startTime when play is pressed
@@ -202,11 +200,8 @@ export function VideoEditor({ file, onComplete, onCancel, onError }: VideoEditor
     e.preventDefault()
     e.stopPropagation()
 
-    // Stop playback and preview at marker position
+    // Stop playback — safePause is handled by the effect cleanup
     if (playing) {
-      if (videoRef.current) {
-        safePause(videoRef.current)
-      }
       setPlaying(false)
     }
 
@@ -252,11 +247,8 @@ export function VideoEditor({ file, onComplete, onCancel, onError }: VideoEditor
     e.preventDefault()
     e.stopPropagation()
 
-    // Stop playback and preview at marker position
+    // Stop playback — safePause is handled by the effect cleanup
     if (playing) {
-      if (videoRef.current) {
-        safePause(videoRef.current)
-      }
       setPlaying(false)
     }
 


### PR DESCRIPTION
video.play() returns a Promise, and calling pause() before it resolves
causes an AbortError. Repeated unhandled AbortErrors cause the browser
to throttle/refuse play() calls, freezing the video player.

Add safePause() helper that waits for the pending play() Promise to
resolve before calling pause(), and catch AbortError on all play() calls.

https://claude.ai/code/session_019Ug2UeMnSzsBXLcdYUrPNe