### PR TITLE
fix: 合成UIをワードロット一覧の上に移動 (#71)

### DIFF
--- a/apps/web/src/pages/InventoryPage.tsx
+++ b/apps/web/src/pages/InventoryPage.tsx
@@ -684,6 +684,31 @@ export function InventoryPage() {
                 })
                 return (
                   <>
+                    {/* Synthesis bar (above the list so it's always reachable) */}
+                    <SynthesisPanel
+                      inventory={wordrotInventory}
+                      synthesis={synthesis}
+                      activeSlot={activeSlot}
+                      onSlotTap={handleSlotTap}
+                      onClear={() => setActiveSlot('A')}
+                      onSynthesisComplete={(result) => {
+                        const hadBefore = wordrotInventory.some((item) => item.word.id === result.result.id)
+                        loadWordrotInventory()
+                        setSynthesisCelebration({
+                          ...result,
+                          isNewWord: !hadBefore,
+                        })
+                        setShowSynthesisCelebration(true)
+                      }}
+                      onResultClick={(result) => {
+                        setSynthesisCelebration({
+                          ...result,
+                          isNewWord: false,
+                        })
+                        setShowSynthesisCelebration(true)
+                      }}
+                    />
+
                     <div className="inventory-words-section">
                       <h3>Wordrot ({uniqueWords.length})</h3>
 
@@ -710,31 +735,6 @@ export function InventoryPage() {
                         </div>
                       )}
                     </div>
-
-                    {/* Synthesis bar */}
-                    <SynthesisPanel
-                      inventory={wordrotInventory}
-                      synthesis={synthesis}
-                      activeSlot={activeSlot}
-                      onSlotTap={handleSlotTap}
-                      onClear={() => setActiveSlot('A')}
-                      onSynthesisComplete={(result) => {
-                        const hadBefore = wordrotInventory.some((item) => item.word.id === result.result.id)
-                        loadWordrotInventory()
-                        setSynthesisCelebration({
-                          ...result,
-                          isNewWord: !hadBefore,
-                        })
-                        setShowSynthesisCelebration(true)
-                      }}
-                      onResultClick={(result) => {
-                        setSynthesisCelebration({
-                          ...result,
-                          isNewWord: false,
-                        })
-                        setShowSynthesisCelebration(true)
-                      }}
-                    />
                   </>
                 )
               })()}


### PR DESCRIPTION
## 関連 Issue
closes #71

## 変更内容
- SynthesisPanelをワードロット一覧（inventory-words-grid）の上に移動
- コレクション数が増えても合成UIに常にアクセス可能