### PR TITLE
fix: 動画エディタのクロップハンドル見切れを修正

### DIFF
--- a/apps/web/src/styles/components/video-editor.css
+++ b/apps/web/src/styles/components/video-editor.css
@@ -19,9 +19,9 @@
   justify-content: center;
   align-items: center;
   background: var(--surface-secondary);
-  padding: 0.5rem;
+  padding: 0.75rem;
   margin-bottom: 0.5rem;
-  overflow: hidden;
+  overflow: visible;
   min-height: 200px;
 }
 
@@ -33,13 +33,13 @@
 /* ReactCrop container */
 .video-editor-crop-container {
   max-width: 100%;
-  max-height: 45vh;
-  overflow: hidden;
+  max-height: 35vh;
+  overflow: visible;
 }
 
 .video-editor-video {
   max-width: 100%;
-  max-height: 45vh;
+  max-height: 35vh;
   object-fit: contain;
 }
 


### PR DESCRIPTION
## 関連 Issue
closes #81

## 変更内容
Edit Videoポップアップで ReactCrop の四隅ドラッグハンドルが `overflow: hidden` でクリップされ操作できない問題を修正。

画像エディタ (#73, PR #77) と同じ3点を `video-editor.css` に適用:
- `overflow: hidden` → `overflow: visible`（`.video-editor-content`, `.video-editor-crop-container`）
- `max-height: 45vh` → `max-height: 35vh`（`.video-editor-crop-container`, `.video-editor-video`）
- `padding: 0.5rem` → `0.75rem`（`.video-editor-content`）

## 他のエディタへの影響
ReactCrop を使っているのは ImageEditor と VideoEditor の2つのみ。他に同様の問題はなし。