### PR TITLE
起動時のNostrタイムライン取得をSW更新チェック完了後に遅延

### DIFF
--- a/apps/web/src/hooks/timeline/useTimeline.ts
+++ b/apps/web/src/hooks/timeline/useTimeline.ts
@@ -15,6 +15,7 @@ import {
 import { sendStella, fetchStellaBalance } from '../../lib/api'
 import { getDisplayNameFromCache, getAvatarUrlFromCache, getErrorMessage, getMutedPubkeys } from '../../lib/utils'
 import { getFilterSettings } from '../../lib/storage'
+import { awaitSwCheckThen } from '../../lib/pwa/swCheck'
 import { TIMEOUTS, CUSTOM_EVENTS, LIMITS } from '../../lib/constants'
 import type {
   Event,
@@ -150,12 +151,15 @@ export function useTimeline(options: UseTimelineOptions = {}): UseTimelineResult
       setMyPubkey(pubkey)
 
       const filterOpts = getFilterOptions()
-      let result: { events: Event[]; searchedUntil: number | null }
-      if (authorPubkey) {
-        result = await fetchUserEvents(authorPubkey, { limit: LIMITS.TIMELINE_FETCH_LIMIT, tags, q, ...filterOpts })
-      } else {
-        result = await fetchTimeline({ limit: LIMITS.TIMELINE_FETCH_LIMIT, queries: q, okTags: tags, ...filterOpts })
-      }
+      // SW更新チェック完了を待ってから取得する（#94）。
+      // 更新があれば直後にreloadされるため、無駄なリレー問い合わせを避ける。
+      // waitForSwCheckは一度解決すると解決済みのままなので、起動から
+      // 十分時間が経った後の呼び出し（フィルター変更・reload等）は実質待たされない。
+      const result: { events: Event[]; searchedUntil: number | null } = await awaitSwCheckThen(() =>
+        authorPubkey
+          ? fetchUserEvents(authorPubkey, { limit: LIMITS.TIMELINE_FETCH_LIMIT, tags, q, ...filterOpts })
+          : fetchTimeline({ limit: LIMITS.TIMELINE_FETCH_LIMIT, queries: q, okTags: tags, ...filterOpts })
+      )
       const notes = result.events
 
       // リポスト（kind:6）をTimelineItemに変換し、originalEventsを抽出

--- a/apps/web/src/lib/pwa/swCheck.test.ts
+++ b/apps/web/src/lib/pwa/swCheck.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createSwCheckWaiter, awaitSwCheckThen } from './swCheck'
+
+describe('createSwCheckWaiter', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('onUpdateSucceeded: refreshGraceMs 経過前は resolve しない', async () => {
+    const { promise, onUpdateSucceeded } = createSwCheckWaiter({ refreshGraceMs: 500, timeoutMs: 5000 })
+    let resolved = false
+    promise.then(() => {
+      resolved = true
+    })
+
+    onUpdateSucceeded()
+    await vi.advanceTimersByTimeAsync(499)
+    expect(resolved).toBe(false)
+  })
+
+  it('onUpdateSucceeded: refreshGraceMs 経過後に resolve する', async () => {
+    const { promise, onUpdateSucceeded } = createSwCheckWaiter({ refreshGraceMs: 500, timeoutMs: 5000 })
+    let resolved = false
+    promise.then(() => {
+      resolved = true
+    })
+
+    onUpdateSucceeded()
+    await vi.advanceTimersByTimeAsync(500)
+    expect(resolved).toBe(true)
+  })
+
+  it('onUpdateSkipped: update()失敗・SW未対応時は即座に resolve する', async () => {
+    const { promise, onUpdateSkipped } = createSwCheckWaiter({ refreshGraceMs: 500, timeoutMs: 5000 })
+    let resolved = false
+    promise.then(() => {
+      resolved = true
+    })
+
+    onUpdateSkipped()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(resolved).toBe(true)
+  })
+
+  it('タイムアウト: 何も呼ばれなくても timeoutMs 経過後に resolve する', async () => {
+    const { promise } = createSwCheckWaiter({ refreshGraceMs: 500, timeoutMs: 2000 })
+    let resolved = false
+    promise.then(() => {
+      resolved = true
+    })
+
+    await vi.advanceTimersByTimeAsync(1999)
+    expect(resolved).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(resolved).toBe(true)
+  })
+
+  it('二重解決しても例外を投げず、Promiseは1回だけ解決される', async () => {
+    const { promise, onUpdateSucceeded, onUpdateSkipped } = createSwCheckWaiter({
+      refreshGraceMs: 500,
+      timeoutMs: 5000,
+    })
+    let resolveCount = 0
+    promise.then(() => {
+      resolveCount++
+    })
+
+    expect(() => {
+      onUpdateSkipped()
+      onUpdateSucceeded()
+    }).not.toThrow()
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(resolveCount).toBe(1)
+  })
+})
+
+describe('awaitSwCheckThen', () => {
+  it('渡したPromiseが解決するまでfetcherを呼ばない', async () => {
+    let resolveGate: () => void = () => {}
+    const gate = new Promise<void>((resolve) => {
+      resolveGate = resolve
+    })
+    const fetcher = vi.fn().mockResolvedValue('result')
+
+    const resultPromise = awaitSwCheckThen(fetcher, gate)
+    // マイクロタスクを1周させても、gateが未解決ならfetcherは呼ばれない
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(fetcher).not.toHaveBeenCalled()
+
+    resolveGate()
+    const result = await resultPromise
+    expect(fetcher).toHaveBeenCalledTimes(1)
+    expect(result).toBe('result')
+  })
+
+  it('gateが既に解決済みならfetcherを実行して結果を返す', async () => {
+    const fetcher = vi.fn().mockResolvedValue('ok')
+    const result = await awaitSwCheckThen(fetcher, Promise.resolve())
+    expect(fetcher).toHaveBeenCalledTimes(1)
+    expect(result).toBe('ok')
+  })
+
+  it('fetcherが失敗した場合はそのエラーを伝播する', async () => {
+    const fetcher = vi.fn().mockRejectedValue(new Error('fetch failed'))
+    await expect(awaitSwCheckThen(fetcher, Promise.resolve())).rejects.toThrow('fetch failed')
+  })
+})

--- a/apps/web/src/lib/pwa/swCheck.ts
+++ b/apps/web/src/lib/pwa/swCheck.ts
@@ -1,0 +1,82 @@
+// PWA Service Worker 更新チェック完了を待つための仕組み（Agasteer方式の移植）。
+//
+// 起動直後にNostrリレーへの初回タイムライン取得を始めてしまうと、
+// 直後にSW更新でリロードされた場合にその問い合わせが無駄になる。
+// このモジュールは「SW登録→update()→onNeedRefresh発火猶予」を待つ
+// Promise（waitForSwCheck）を提供し、初回フェッチ側（useTimeline）が
+// これをawaitしてから重い呼び出し（Nostrリレーへの問い合わせ）を行う。
+//
+// 実際の registerSW() 呼び出しと onNeedRefresh の overlay/cooldown ロジックは
+// main.tsx が担う。このモジュールは DOM に触れないため、テスト側から
+// import しても副作用（mount 等）が発生しない。
+
+export interface SwCheckWaiterOptions {
+  /** update() 成功後、onNeedRefresh 発火を待つ猶予（ms） */
+  refreshGraceMs?: number
+  /** SW登録自体が完了しない場合に諦めるまでの絶対タイムアウト（ms） */
+  timeoutMs?: number
+}
+
+export interface SwCheckWaiterHandle {
+  /** SW更新チェックの完了（または断念）を表すPromise */
+  promise: Promise<void>
+  /** swRegistration.update() が成功した時に呼ぶ */
+  onUpdateSucceeded: () => void
+  /** update() が失敗した時、またはSW未対応環境の時に呼ぶ */
+  onUpdateSkipped: () => void
+}
+
+export function createSwCheckWaiter(options: SwCheckWaiterOptions = {}): SwCheckWaiterHandle {
+  const { refreshGraceMs = 500, timeoutMs = 2000 } = options
+
+  let resolved = false
+  let resolvePromise: () => void
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve
+  })
+
+  const safeResolve = () => {
+    if (resolved) return
+    resolved = true
+    resolvePromise()
+  }
+
+  const onUpdateSucceeded = () => {
+    // 更新チェック完了後、onNeedRefreshが呼ばれる猶予を与える
+    setTimeout(safeResolve, refreshGraceMs)
+  }
+
+  const onUpdateSkipped = () => {
+    safeResolve()
+  }
+
+  // SWがサポートされていない環境や登録に時間がかかる場合のフォールバック
+  setTimeout(safeResolve, timeoutMs)
+
+  return { promise, onUpdateSucceeded, onUpdateSkipped }
+}
+
+// アプリ全体で共有する単一インスタンス。main.tsx の registerSW コールバックが
+// onUpdateSucceeded / onUpdateSkipped を呼び分けて解決する。
+const swCheckWaiter = createSwCheckWaiter()
+
+/** main.tsx の onMount 相当（初回起動）でのみ待つべきPromise */
+export const waitForSwCheck: Promise<void> = swCheckWaiter.promise
+export const onSwUpdateSucceeded = swCheckWaiter.onUpdateSucceeded
+export const onSwUpdateSkipped = swCheckWaiter.onUpdateSkipped
+
+/**
+ * SW更新チェック完了を待ってから fetcher を実行する。
+ * mypace起動直後の初回タイムライン取得（useTimeline の loadTimeline）専用。
+ * ポーリングによる2回目以降の取得（useTimelinePolling の checkNewEvents）は対象外。
+ *
+ * waitForSwCheck は一度解決すると解決済みのまま保持されるため、アプリ起動から
+ * 十分時間が経った後に呼ばれた場合は実質的に待たされない。
+ */
+export async function awaitSwCheckThen<T>(
+  fetcher: () => Promise<T>,
+  swCheck: Promise<void> = waitForSwCheck
+): Promise<T> {
+  await swCheck
+  return fetcher()
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import { registerSW } from 'virtual:pwa-register'
 import { initSecretKeyCache } from './lib/storage'
+import { onSwUpdateSkipped, onSwUpdateSucceeded } from './lib/pwa/swCheck'
 import App from './App'
 import './index.css'
 
@@ -23,9 +24,19 @@ const updateSW = registerSW({
   onRegistered(swRegistration) {
     if (swRegistration) {
       // Check for updates on registration
-      swRegistration.update().catch((error) => {
-        console.info('SW update check skipped:', error?.message || 'offline')
-      })
+      swRegistration
+        .update()
+        .then(() => {
+          // 更新チェック完了 → waitForSwCheck 解決へ（猶予後）
+          onSwUpdateSucceeded()
+        })
+        .catch((error) => {
+          console.info('SW update check skipped:', error?.message || 'offline')
+          onSwUpdateSkipped()
+        })
+    } else {
+      // SW未対応環境 → 待つ意味がないので即解決
+      onSwUpdateSkipped()
     }
   },
   onNeedRefresh() {

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -195,6 +195,8 @@ src/
 │   ├── utils/           # ユーティリティ
 │   ├── storage/         # localStorage管理
 │   ├── constants/       # 定数
+│   ├── pwa/             # PWA関連（SW更新チェック待ち等）
+│   │   └── swCheck.ts   # waitForSwCheck（起動時Nostr取得の遅延ゲート）
 │   └── parser/          # コンテンツパーサー
 │       ├── content-parser.tsx
 │       ├── emoji.ts


### PR DESCRIPTION
## 概要

Agasteerの `waitForSwCheck` パターンを移植し、起動直後のNostrタイムライン初回取得をSW更新チェック完了後に遅延させる。

- `apps/web/src/lib/pwa/swCheck.ts`: `waitForSwCheck: Promise<void>` を新設。SW登録→`update()`成功→`onNeedRefresh`発火猶予（500ms）を経てから解決。`update()`失敗時・SW未対応環境では即座に解決。絶対タイムアウト（2秒）あり。
- `apps/web/src/main.tsx`: `registerSW`の`onRegistered`から`onSwUpdateSucceeded`/`onSwUpdateSkipped`を呼び分けて`waitForSwCheck`を解決するよう配線。既存の`onNeedRefresh`（overlayの表示・cooldownによるループ防止・reload）ロジックは変更なし。
- `apps/web/src/hooks/timeline/useTimeline.ts`: `loadTimeline`の初回フェッチ（`fetchTimeline`/`fetchUserEvents`）を`awaitSwCheckThen`でラップし、`waitForSwCheck`解決後に実行されるようにした。`waitForSwCheck`は一度解決すると解決済みのままなので、起動から時間が経った後の呼び出し（フィルター変更・reload等）は実質待たされない。`useTimelinePolling`の`checkNewEvents`（1分ごとのポーリング）は対象外（未変更）。

## テスト

`apps/web/src/lib/pwa/swCheck.test.ts` を追加（8ケース）:
- `onUpdateSucceeded`: 猶予経過前は未解決／経過後に解決
- `onUpdateSkipped`: 即座に解決
- タイムアウト境界（2秒経過で解決）
- 二重解決してもエラーにならない
- `awaitSwCheckThen`: gate未解決中はfetcher未実行／解決後に実行／gate解決済みなら即実行／fetcher失敗時はエラー伝播

`pnpm test` / `pnpm typecheck` / `pnpm lint` / `vite build` すべて確認済み。

## 実機確認

Issueの完了条件に「実機またはbuild previewで、更新検知時にタイムライン取得前にreloadされることを確認」とあるため、**実機確認が完了するまでこのPRはopenのまま維持する**。

Refs #94